### PR TITLE
add fake_execution parameter to ConfigurationExecutor

### DIFF
--- a/rosa_execute/rosa_execute/configuration_executor.py
+++ b/rosa_execute/rosa_execute/configuration_executor.py
@@ -69,6 +69,8 @@ class ConfigurationExecutor(Node):
         self.active = False
         self.cb_group = MutuallyExclusiveCallbackGroup()
 
+        self.declare_parameter('fake_execution', False)
+
     def on_configure(self, state: State) -> TransitionCallbackReturn:
         self.get_logger().info(self.get_name() + ': on_configure() is called.')
 
@@ -203,6 +205,10 @@ class ConfigurationExecutor(Node):
 
     @check_lc_active
     def perform_reconfiguration_plan(self, reconfig_plan):
+        if self.get_parameter('fake_execution').value is True:
+            self.get_logger().info('Fake execution enabled, skipping reconfiguration.')
+            return True
+
         result_deactivation = self.deactivate_components(
             reconfig_plan.components_deactivate)
         result_activation = self.activate_components(

--- a/rosa_execute/test/test_executor.py
+++ b/rosa_execute/test/test_executor.py
@@ -399,6 +399,36 @@ def test_perform_reconfiguration_plan(
 
 @pytest.mark.launch(fixture=generate_test_description)
 @pytest.mark.usefixtures(fixture=tester_node)
+def test_fake_perform_reconfiguration_plan(
+   configuration_executor_node, tester_node):
+    try:
+        tester_node.activate_lc_node(rosa_kb_name)
+
+        component = Component()
+        component.name = 'fake'
+        component.package = 'rosa_execute'
+        component.executable = 'configuration_executor'
+        component.node_type = 'LifeCycleNode'
+
+        config = ComponentConfiguration(name='fake_config')
+
+        reconfig_plan = ReconfigurationPlan()
+        reconfig_plan.components_deactivate = [component]
+        reconfig_plan.components_activate = [component]
+        reconfig_plan.component_configurations = [config]
+
+        configuration_executor_node.set_parameters([rclpy.parameter.Parameter(
+            'fake_execution', rclpy.Parameter.Type.BOOL, True)])
+        result = configuration_executor_node.perform_reconfiguration_plan(
+            reconfig_plan)
+
+        assert result is True
+
+    finally:
+        configuration_executor_node.kill_all_components()
+
+@pytest.mark.launch(fixture=generate_test_description)
+@pytest.mark.usefixtures(fixture=tester_node)
 def test_execute(configuration_executor_node, tester_node):
     try:
         tester_node.activate_lc_node(rosa_kb_name)
@@ -429,7 +459,7 @@ def test_execute(configuration_executor_node, tester_node):
             ParameterValue(type=1, bool_value=True),
             ParameterValue(type=1, bool_value=False),
             ParameterValue(
-                type=9, string_array_value=["test_data/test_data.tql"]),
+                type=9, string_array_value=['test_data/test_data.tql']),
         ]
         assert component_state.current_state.id == 2 and \
             'executor_mock' in active_nodes and \


### PR DESCRIPTION
@MnM03 I added a `fake_execution` parameter  to the `ConfigurationExecutor` node. If you set it to `True` it doesn't try to actually perform the reconfiguration. Does this solve the fake execution problem for you?

closes https://github.com/kas-lab/rosa/issues/109